### PR TITLE
definition: Update for new JJB API

### DIFF
--- a/jjb_pipeline/definition.py
+++ b/jjb_pipeline/definition.py
@@ -9,7 +9,7 @@ class Pipeline(jenkins_jobs.modules.base.Base):
     component_type = 'pipeline'
     component_list_type = 'pipeline'
 
-    def gen_xml(self, parser, xml_parent, data):
+    def gen_xml(self, xml_parent, data):
         definition = data.get(self.component_type, {})
 
         scm_definition = 'scm' in definition
@@ -26,7 +26,7 @@ class Pipeline(jenkins_jobs.modules.base.Base):
 
         if scm_definition:
             scm_module = next(module for module in self.registry.modules if isinstance(module, SCM))
-            scm_module.gen_xml(parser, xml_definition, definition)
+            scm_module.gen_xml(xml_definition, definition)
             XML.SubElement(xml_definition, 'scriptPath').text = definition.get('script-path', 'Jenkinsfile')
         else:
             XML.SubElement(xml_definition, 'script').text = definition.get('script', '')


### PR DESCRIPTION
Commit ae1fb60f16 in jenkins-job-builder updated the XML generator API
to no longer require the YAML parser. Update our definition to match.

This will break every released version, but conversely is required for
1.6.2.
